### PR TITLE
direct import resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -12,9 +12,13 @@
   * Type aliases
   * [Const declarations, override declarations](https://www.w3.org/TR/WGSL/#value-decls)
   * [Var declarations](https://www.w3.org/TR/WGSL/#var-decls)
-* **Module**: A single WESL or WGSL file.
+* **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
+* **Module Source**: The stored text of a module, typically a WESL or WGSL file.
 * **Root Module**: The WESL module from which translation starts. A single project can have many root modules.
-* **Module Path**: Hierarchical address of a module file or partial path, akin to a filesystem path
+* **Declaration Path**: A fully qualified `::`-separated path whose final segment names a declared item.
+* **Module Path**: A `::`-separated path naming a module; equivalently, a declaration path minus its final segment. See [Imports](Imports.md#resolving-a-declaration-path).
+* **Import Path**: The `::`-separated path written in an import statement. An import collection (`{}`) flattens into separate imports, each with its own import path.
+* **Package Module**: The top-level module of a package, stored as the optional file `package.wesl` in the package root. A module path consisting only of `package` or a bare package name refers to the package module.
 * **Side effects**: WESL/WGSL shader code that is visible to host code (e.g. in Rust or JavaScript).
   Changes to that shader code have the side effect of changing the host interface to the shader.
   * Things that are specified when [creating a WGSL pipeline](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipeline#fragment_object_structure)

--- a/Imports.md
+++ b/Imports.md
@@ -131,7 +131,6 @@ The absolute path of the `super` module is always known, since the first loaded 
 Once the import has been resolved, the last segment, or its alias, is brought into scope.
 
 The order of the scopes is "user declarations and imported items > wildcard import > package names > predeclared items".
-This lets WGSL add more predeclared items without breaking existing WESL code. Package names can shadow predeclared items, but we recommend that authors avoid doing that.
 
 
 ### Example
@@ -266,17 +265,34 @@ import bar::*; // exports clashing_name
 The name clash is ignored until the item is used.
 TODO: Or should it immediately result in a warning, even if the variables are unused?
 
-### Wildcard imports from libraries 
+### Diagnostics for best practices
 
-For libraries, we distinguish between modules that were designed for wildcard imports and modules that were not.
-Library authors generally expect that adding a new item is not a breaking change. Wildcard imports are a surprising edge case.
+Many ecosystems rely on semantic versioning for updating libraries. This applies to both direct and transitive dependencies. Updating to the latest patch releases should be easy and safe. 
 
-WESL detects the edge cases and will emit a diagnostic. This makes upholding semver guarantees significantly easier. 
+Library authors generally expect that adding a new item is not a breaking change. Wildcard imports that result in name clashes are a surprising edge case. Therefore, we want to reduce the risk of accidental name clashes.
 
-When the library module is called `prelude`, it is a module designed for wildcards. Adding a new item to it is a semver breaking change.
-Wildcard importing from it is always allowed. (When we add exports, we will make this controllable instead of only giving special treatment to the `prelude`.)
+Name clashes can happen either in user code or in library code. If it happens in library code, it can be significantly harder to resolve the issue. 
 
-Other library modules are not designed for wildcards. If another wildcard import exists, then an `wildcard_import` [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) at the error level will be emitted.
+A secondary, similar issue is that wildcards can result in accidental shadowing of predeclared identifiers. 
+One especially insideous scenario is when user code targets an unstable Naga feature.
+
+```wesl
+import my_lib::*;
+
+const x = unstable_thing();
+```
+
+Then, a library which does not know about the Naga feature could add an item with the same name. 
+
+To reduce the odds of these cases, we recommend the following diagnostics.
+
+1. Emit a warning [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) named `builtin_shadowing` if an top level item is declared that is known to conflict with a predeclared identifier. This also helps in the non-library case.
+
+2. Emit a warning [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) named `wildcard_import` if there are multiple wildcard imports from libraries and at least one is not designed for wildcards.
+
+For this, we distinguish between modules that were designed for wildcard imports and modules that were not. When the library module is called `prelude`, it is a module designed for wildcards. Adding a new item to it is a semver breaking change. Therefore, wildcard importing from it is always allowed. (When we add exports, we will make this controllable instead of only giving special treatment to the `prelude`.)
+
+Other library modules may cause issues and should not be combined with other wildcard imports.
 
 Modules in the same package can always be wildcard imported. Changing your own code has no impact on semver.
 
@@ -298,6 +314,18 @@ import package::utils::*;
 @diagnostic(off, wildcard_import) 
 import lygia::math::*; 
 ```
+
+### Modeling the WGSL predeclared identifiers
+
+One mental model for WGSL predeclared identifiers is that they're a wildcard import, which is implicitly added to every WGSL file. 
+
+```wesl
+// imports all the predeclared identifiers
+import all_wgsl_items::*;
+```
+
+This wildcard import has a strictly lower priority than all other wildcard imports. This lets WGSL add more predeclared items without breaking existing WESL code. Package names can also shadow predeclared items, but we recommend that authors avoid doing that.
+
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -22,6 +22,9 @@ import my::geom::sphere::{ draw, default_radius as foobar };
 
 // Imports a whole module. Use it with `bevy_ui::name`
 import bevy_ui;
+
+// Import all items defined in the bevy prelude
+import bevy::prelude::*;
 ```
 
 These can then be used anywhere in the source code.
@@ -74,6 +77,7 @@ import_relative:
 import_path_or_item:
 | ident '::' (import_collection | import_path_or_item) 
 | ident ('as' ident)?
+| '*'
 
 import_collection:
 | '{' (import_path_or_item) (',' (import_path_or_item))* ','? '}'
@@ -90,6 +94,8 @@ Lint tools may optionally warn when reserved words are used.
 An item import imports a single item. The item can be renamed with the `as` keyword.
 
 An import collection imports multiple items, and allows for nested imports.
+
+A wildcard import imports all items from a module, but does not import further modules.
 
 ### Import resolution algorithm
 
@@ -111,8 +117,9 @@ Then, one iterates over each segment from left to right, and looks it up one by 
 2. We take that as the "current module".
 3. We repeatedly look at the next segment.
     1. Item in current module: Take that item. We must be at the last segment, otherwise it's an error.
-    2. (Else if re-exported or inline module in current module: We continue with that module.)
-    3. Else go to `current module path/ident.wesl`
+    2. Wildcard import: Take all items in the current module.
+    3. (Else if re-exported or inline module in current module: We continue with that module.)
+    4. Else go to `current module path/ident.wesl`
        * File found: We take that file as the current module.
        * File not found: We assume an empty module as the current module, and continue with that.
        * (Re-exporting changes the path.)
@@ -123,7 +130,7 @@ The absolute path of the `super` module is always known, since the first loaded 
 
 Once the import has been resolved, the last segment, or its alias, is brought into scope.
 
-The order of the scopes is "user declarations and imported items > package names > predeclared items".
+The order of the scopes is "user declarations and imported items > wildcard import > package names > predeclared items".
 This lets WGSL add more predeclared items without breaking existing WESL code. Package names can shadow predeclared items, but we recommend that authors avoid doing that.
 
 
@@ -244,6 +251,53 @@ const b = a + 1;
 (a depends on b which depends on a)
 
 Basic linker implementations do not need to check for this. Generating broken code and letting the underlying shader compiler throw an error is fine.
+
+## Wildcard Imports
+
+Wildcard imports are used to import a whole set of items into the current module. They are lower priority than local names and explicit imports to reduce the chance of breaking changes if the wildcard-imported module changes. Wildcard imported modules are eagerly loaded, since they need to be checked before accessing any predeclared items.
+
+When multiple wildcard imports are used, name clashes are possible.
+
+```wesl
+import foo::*; // exports clashing_name
+import bar::*; // exports clashing_name
+```
+
+The name clash is ignored until the item is used.
+TODO: Or should it immediately result in a warning, even if the variables are unused?
+
+### Wildcard imports from libraries 
+
+For libraries, we distinguish between modules that were designed for wildcard imports and modules that were not.
+Library authors generally expect that adding a new item is not a breaking change. Wildcard imports are a surprising edge case.
+
+WESL detects the edge cases and will emit a diagnostic. This makes upholding semver guarantees significantly easier. 
+
+When the library module is called `prelude`, it is a module designed for wildcards. Adding a new item to it is a semver breaking change.
+Wildcard importing from it is always allowed. (When we add exports, we will make this controllable instead of only giving special treatment to the `prelude`.)
+
+Other library modules are not designed for wildcards. If another wildcard import exists, then an `wildcard_import` [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) at the error level will be emitted.
+
+Modules in the same package can always be wildcard imported. Changing your own code has no impact on semver.
+
+Examples
+
+```wesl
+// Allowed, since it is the only import in the current module
+import lygia::math::*; 
+```
+
+```wesl
+// Allowed, since it is designed for wildcards
+import bevy::color::prelude::*; 
+
+// Allowed, same package
+import package::utils::*; 
+
+// Requires opt-in
+@diagnostic(off, wildcard_import) 
+import lygia::math::*; 
+```
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -333,8 +333,12 @@ applications.
 
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
 expected semantics that oughtn't be implicitly overridden with wildcards.
-Similarly, avoid experimental Naga/Dawn/Safari builtins. Consumers of the
-module will see a `builtin_shadow` warning at the import site.
+Similarly, avoid experimental Naga/Dawn/Safari builtins.
+- WESL publishing tools should warn when a `@wildcardable` module exports an
+  item that shadows a WGSL builtin. Suppress with
+  `@diagnostic(off, builtin_shadow)` if the shadow is intentional.
+- Consumers of the module will also see a `builtin_shadow` warning at the
+  import site.
 - If a future WGSL update adds a conflicting builtin name, plan to update the
   `@wildcardable` module to rename the conflicting item.
 
@@ -371,7 +375,7 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
 | Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`); suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`); suppressible |
-| Wildcard import shadows a WGSL builtin | Warning (`builtin_shadow`); suppressible |
+| Wildcard import shadows a WGSL builtin (when name is referenced) | Warning (`builtin_shadow`) on the import; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
 more than one module:
@@ -396,10 +400,11 @@ is referenced.
   name brought in by a wildcard import. The local wins by precedence (see
   [Scope precedence](#scope-precedence)).
 
-- **`builtin_shadow`** fires when a wildcard import shadows a WGSL builtin such
+- **`builtin_shadow`** fires on a wildcard import when a referenced name in the
+  module resolves to a wildcard-imported item that shadows a WGSL builtin such
   as `vec3` or `clamp`. Suppress at the import site if the override is
-  intentional; the suppression itself documents documents to readers that the
-  builtins have changed semantics.
+  intentional; the suppression itself documents to readers that the builtins
+  have changed semantics.
 
 ## Scope precedence
 

--- a/Imports.md
+++ b/Imports.md
@@ -109,6 +109,8 @@ module_declaration:
 | attribute* 'module' ';'
 ```
 
+A file may have at most one `module` declaration.
+
 ### Import resolution algorithm
 
 To resolve the import, the recursive structure is flattened out. This means turning every `import_collection` into multiple separate imports, ending with the items.

--- a/Imports.md
+++ b/Imports.md
@@ -11,16 +11,16 @@ We also should account for **importing shader from libraries**. Ideally, users c
 Finally, we want **multiple tools** which can compile WGSL-with-imports down to raw WGSL. Using WGSL-with-imports both in Rust projects and in web projects should be possible.
 
 # Guide-level explanation
-The `import` statement extension brings items or entire modules into scope. Import statements map to files with minimal searching.
+The `import` statement extension brings item or module names into scope.
 
-```wgsl
+```wesl
 // Importing a single function using a relative path
 import super::lighting::pbr;
 
 // Importing multiple items
 import my::geom::sphere::{ draw, default_radius as foobar };
 
-// Imports a whole module. Use it with `bevy_ui::name`
+// Imports a module name. Use it with `bevy_ui::name`
 import bevy_ui;
 
 // Import all items from another module
@@ -30,18 +30,18 @@ import wgsl_test::expect::*;
 
 These can then be used anywhere in the source code.
 
-```wgsl
+```wesl
 fn main() {
     bevy_ui::quad(vec2f(0.0, 1.0), 1.0);
     let a = draw(3);
 }
 ```
 
-Both `bevy_ui` and `my` are packages in the current project. Language servers and related tools can look in a `wesl.toml` file to find the location of the packages. This lets libraries be published to package managers, and users can import them with a simple syntax.
+Both `bevy_ui` and `my` are packages in the current project, typically installed by a package manager.
 
 Recursive import definitions are also supported, which leads to shorter import statements.
 
-```wgsl
+```wesl
 import bevy_pbr::{
   forward_io::VertexOutput,
   pbr_types::{PbrInput, pbr_input_new},
@@ -49,17 +49,15 @@ import bevy_pbr::{
 };
 ```
 
-To find the relevant items, the following algorithm is used:
-
-Proceeding left to right through the path segments, consider the segments `prev` and `seg`.
-1. if `prev.wesl` exists and includes WESL elements, check if `seg` is one of those elements, e.g. `fn seg` or `namespace seg`.
-2. else if the directory `prev/` exists, check to see if the file `seg.wesl` or the directory `seg/` is in the `prev/` directory;
-3. error if a `seg` is not found.
+*Import paths* map directly to modules and their items. Each module is stored
+in a single source, typically a WESL or WGSL file: so
+`bevy_pbr::pbr_types::PbrInput` names the item `PbrInput` declared in the
+source file `pbr_types.wesl` in the `bevy_pbr` package.
 
 # Reference-level explanation
 A WESL program is composed of a tree of WESL modules.
 
-Imports must appear as the first items in a WESL file. They can import entire modules or individual "importable items" (see [GLOSSARY](GLOSSARY.md)).
+Imports must appear at the beginning of a WESL file. They can bind the name of a module or of an individual "importable item" (see [GLOSSARY](GLOSSARY.md)).
 
 ### Grammar
 
@@ -92,13 +90,17 @@ not current keywords are allowed,
 but not recommended.
 Lint tools may optionally warn when reserved words are used. 
 
+Attributes may precede an import statement, notably `@if` for
+[conditional translation](ConditionalTranslation.md) and `@diagnostic` for
+[suppressible diagnostics](#suppressible-diagnostics).
+
 An item import imports a single item. The item can be renamed with the `as` keyword.
 
 An import collection imports multiple items, and allows for nested imports.
 
-A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported. A wildcard must follow a module path; a bare `import *;` is an error. A wildcard may also appear as a member of an import collection, applying to the module path before the braces (see [Import resolution algorithm](#import-resolution-algorithm)).
+A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported. A wildcard must follow a module path; a bare `import *;` is an error. A wildcard may also appear as a member of an import collection, applying to the module path before the braces (see [Import bindings](#import-bindings)).
 
-WESL also extends WGSL's `global_directive` rule with a *module attribute*: a `@!`-prefixed attribute that carries module-level metadata. It is used by `@!wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata.
+WESL also extends WGSL's `global_directive` rule with a *module attribute*: a `@!`-prefixed attribute that carries module-level metadata. It is used by `@!wildcardable` (see [Wildcard imports](#wildcard-imports)) and is otherwise reserved for future use.
 
 ```ebnf
 global_directive:
@@ -115,9 +117,9 @@ after the `@`, and is terminated with `;`; `ident_pattern_token` and
 module attributes appear after any imports and before any global declarations,
 and apply to the module they appear in.
 
-### Import resolution algorithm
+### Import bindings
 
-To resolve the import, the recursive structure is flattened out. This means turning every `import_collection` into multiple separate imports, ending with the items.
+An import statement's recursive structure is first flattened, turning every `import_collection` into multiple separate imports.
 For instance, `import a::{b, c::{d, e as f}};` would be turned into
 
 ```wesl
@@ -137,59 +139,129 @@ import foo::*;
 The wildcard imports only `foo`'s own top-level declarations: the sibling
 branch reaching into submodule `foo::a` doesn't widen it.
 
-Then, one iterates over each segment from left to right, and looks it up one by one.
+Each flattened import statement binds one name in the importing module: the
+last segment of its *import path*, or its `as` alias. The binding is a
+shorthand for the import path. Each *reference*, a use of a name in code
+(such as in a function call, type, attribute argument, or other expression),
+determines a declaration path: a bound name expands to its import path, and
+any `::` segments written after it extend the path
+(see [Inline Usage](#inline-usage)).
 
-1. We start with the first segment.
-    * `super` refers to the parent module. Can be repeated to go up multiple parent modules. Exiting the root is an error.
-    * `package` refers to the top level module of the current package.
-    * `ident` must be a known package, usually found in the `wesl.toml` file. It refers to the top level module of that package.
-2. We take that as the "current module".
-3. We repeatedly look at the next segment.
-    1. Item in current module: Take that item. We must be at the last segment, otherwise it's an error.
-    2. Wildcard import: Take all items in the current module.
-    3. (Else if re-exported or inline module in current module: We continue with that module.)
-    4. Else go to `current module path/ident.wesl`
-       * File found: We take that file as the current module.
-       * File not found: We assume an empty module as the current module, and continue with that.
-       * (Re-exporting changes the path.)
-       * (Inline modules do not have a path.)
+How a bound name is used determines whether it refers to a declaration or a
+module:
 
-To get an absolute path to a module, one follows the algorithm above. In step 1, one takes the known absolute path of the `super` module, or the package.
-The absolute path of the `super` module is always known, since the first loaded WESL file must always be the root module, and children are only discovered from there.
+```wesl
+import bevy_pbr::forward_io;
 
-Once the import has been resolved, the last segment, or its `as` alias, is brought into scope.
+fn main() {
+    var out: forward_io::VertexOutput;  // forward_io used as a module:
+                                        //   the file bevy_pbr/forward_io.wesl
+    let x = forward_io();               // forward_io used as a declaration:
+                                        //   fn forward_io declared in bevy_pbr/package.wesl
+}
+```
 
+A declaration and a module may share the same name: a bare `forward_io`
+refers to the declaration, while `forward_io::VertexOutput` reaches into the
+module.
 
-### Example
+### Resolving a declaration path
 
-For example
+A *declaration path* is a fully qualified path whose final segment names a
+declared item. The segments before the final segment are the *module path*,
+naming the module containing the declaration. In
+`bevy_pbr::forward_io::VertexOutput`, `VertexOutput` is declared in the
+module named by `bevy_pbr::forward_io`. Each module path names exactly one
+*module source*: the stored text of a module, typically a file.
 
-```wgsl
+The first segment anchors the path:
+
+* `package` anchors the path at the current package.
+* `super` refers to the parent of the current module, removing the last
+  segment of the current module's path. Each additional `super` removes
+  another segment; it is an error to remove beyond the package root.
+* Any other first segment must name a known package, and anchors the path at
+  that package. Tools find the known packages in the
+  [`wesl.toml`](WeslToml.md) file or through the host package manager's
+  dependencies.
+
+A package amounts to a mapping from module paths to module sources; the
+semantics of the module path segments beyond the first are specific to the
+package's storage. Only the module path maps to storage; the final segment of
+a declaration path names a declaration inside the module source, never a file.
+For a package stored on a filesystem, the first segment refers to the
+package's root directory; each following segment except the last names a
+subdirectory, and the last segment of the module path names the source file:
+`seg.wesl`, or `seg.wgsl` when no `.wesl` file exists
+(see [Filesystem Resolution](#filesystem-resolution)). A
+package served over the web can map each module path to a URL, and a bundled
+library can store module sources in a dictionary keyed by module path.
+
+A module path may consist of just `package`, or of just a bare package name.
+Such a path refers to the *package module*: on a filesystem,
+the file `package.wesl` in the package's root directory. The package module
+is optional.
+
+Referencing a declaration path that fails to resolve is an error. An import
+statement whose bound name is never referenced is allowed, even if
+referencing it would be an error; tools may warn about unused or unresolvable
+imports. Import statements and references removed by
+[conditional translation](ConditionalTranslation.md) are also allowed, even
+if they would be errors under other conditions; tools may warn about these
+too.
+
+Tools can enumerate the potential resolutions an import statement
+enables by analyzing the source tree paths and the declarations in each
+module source, for example to suggest editor auto-completions.
+
+For a wildcard import, the entire path before the `*` is a module path; the
+wildcard brings the module's top-level declarations into scope.
+
+### Examples
+
+```wesl
 import bevy_pbr::forward_io::VertexOutput;
+
+@fragment
+fn fragMain(v: VertexOutput) -> @location(0) vec4f { /* ... */ }
 ```
 
-This first looks for `bevy_pbr.wesl`.
-`bevy_pbr.wesl` is found, and doesn't contain an item named `forward_io`.
-Thus, we go to `bevy_pbr/forward_io.wesl`. It contains a struct named `VertexOutput`.
+The reference `VertexOutput` in `v: VertexOutput` determines the declaration
+path `bevy_pbr::forward_io::VertexOutput`. The module path is
+`bevy_pbr::forward_io`, and the final segment refers to a declaration named
+`VertexOutput` in that module (a struct, not shown). `bevy_pbr` is a package,
+so the module source is the file `forward_io.wesl` in the `bevy_pbr`
+package's root directory, or `forward_io.wgsl` if there is no `.wesl` file.
+No other file is consulted; if both files are missing, the reference is an
+error.
 
-Another example
-
-```wgsl
+```wesl
+// lighting/pbr.wesl
 import super::shadowmapping;
+
+fn shade() {
+    let s = shadowmapping::pcf();
+}
 ```
 
-Assume that the current module lives at `shaders/lighting.wesl`. We first go to the super module at `shaders.wesl`. We then look for an item called `shadowmapping` in `shaders.wesl`.
-After not finding it, we look for a module `shadowmapping` at `shaders/shadowmapping.wesl`.
+The current module is stored at `lighting/pbr.wesl`, with module path
+`package::lighting::pbr`. `super` removes the last segment, giving
+`package::lighting`. The import binds `shadowmapping` as a shorthand for
+`package::lighting::shadowmapping`. The reference `shadowmapping::pcf()`
+determines the declaration path `package::lighting::shadowmapping::pcf`,
+referring to a function `pcf` declared in `lighting/shadowmapping.wesl` (not
+shown).
 
 ## `wesl.toml`
-The [`wesl.toml`](WeslToml.md) file provides linker configuration options affecting the import resolution algorithm. It can customize:
+The [`wesl.toml`](WeslToml.md) file provides linker configuration options affecting import resolution. It can customize:
 
 * The root directory,
 * Available package dependencies,
 * A file whitelist and/or blacklist.
 
 ## Filesystem Resolution
-To resolve a module on a filesystem, one follows the algorithm above.
+To resolve a module on a filesystem, one follows the mapping in
+[Resolving a declaration path](#resolving-a-declaration-path).
 The root folder, or the root module, needs to be provided to the linker. This is currently a linker-specific API, and may change once we introduce a `wesl.toml`.
 
 Linkers should fall back to `.wgsl` files when a `.wesl` file cannot be found.
@@ -242,17 +314,18 @@ type_specifier:
 | full_ident ...
 ```
 
-When resolving inline imports, we can also use modules that were imported. This means that the import resolution algorithm is extended to
-1. We start with the first segment.
-    * ...
-    * `ident` refers to an identifier that is in scope. If it is a module, we start with that. If it is not a module, it is an error. If there is none, we fall back to the packages.
+In an inline declaration path, the first segment may also be a name bound by
+an import, which expands to its import path. Otherwise, the first segment
+anchors the path as in
+[Resolving a declaration path](#resolving-a-declaration-path): `package`,
+`super`, or a known package name.
 
-Examples
+### Examples
 
 ```wesl
 import foo::bar;
 fn main() {
-    let a = bar::baz; // Uses bar from the import above
+    let a = bar::baz; // bar expands to foo::bar, from the import above
     let b = bevy::main(); // Uses the known bevy package
 }
 ```
@@ -264,13 +337,13 @@ However, the following is still illegal.
 
 ```wesl
 // foo.wesl
-import bar::b;
+import package::bar::b;
 const a = b + 1;
 ```
 
 ```wesl
 // bar.wesl
-import foo::a;
+import package::foo::a;
 const b = a + 1;
 ```
 
@@ -284,7 +357,7 @@ Wildcard imports bring all items from another module into the importing module's
 scope.
 
 Users can wildcard import:
-- from any other module in the local package.
+- from any other module in the current package.
 - from any external library module where the library author has added a
   `@!wildcardable` annotation.
 
@@ -300,11 +373,11 @@ Advanced users who wish to wildcard import from external modules not marked as
 [Suppressible diagnostics](#suppressible-diagnostics)).
 
 ```wesl
-// wildcard import from a @!wildcardable external
+// wildcard import from a @!wildcardable external module
 import bevy::prelude::*;
 import wgsl_test::expect::*;
 
-// wildcard import from within the local package
+// wildcard import from within the current package
 import package::utils::*;
 import super::fun::*;
 ```
@@ -334,16 +407,16 @@ version bumps but can break users who have local declarations or import other
 - **Document** additions clearly in changelogs so downstream users debugging
   unexpected name resolution can trace them.
 
-**Compose with re-exports.** See [Re-exports](#re-exports) (TBD) to collect
-items from other modules into a single `@!wildcardable` module for user
-convenience.
+**Compose with re-exports.** A future re-exports mechanism (TBD) could
+collect items from other modules into a single `@!wildcardable` module for
+user convenience.
 
 **Avoid generic names.** Prefer domain-specific names. Common names like
 `Buffer`, `Config`, `Result`, `Vec`, etc. are more likely to collide with user
 applications.
 
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
-expected semantics that oughtn't be implicitly overridden with wildcards.
+expected semantics that should not be implicitly overridden with wildcards.
 Similarly, avoid experimental Naga/Dawn/Safari builtins.
 - The `builtin_shadow` diagnostic flags this (see
   [Suppressible diagnostics](#suppressible-diagnostics)).
@@ -381,16 +454,16 @@ library can't introduce conflicts into already-published code.
 
 ## Import errors and warnings
 
-WESL emits errors for name collisions and for unsupported wildcard imports,
-and warnings for shadowing that could surprise readers. Genuine
-collisions cannot be suppressed; other diagnostics are suppressible via
-`@diagnostic`.
+The table below summarizes import errors and warnings. Resolution failures
+and genuine collisions cannot be suppressed; other diagnostics are
+suppressible via `@diagnostic`.
 
 | Situation | Behavior |
 | --- | --- |
+| Reference fails to resolve (missing module source, or no such declaration) | Error |
 | Local declaration conflicts with named import | Error |
 | Named import conflicts with named import | Error |
-| Wildcard import conflicts with wildcard import (when name is referenced) | Error |
+| Wildcard imports provide different declarations for the same referenced name | Error |
 | Wildcard import from a non-`@!wildcardable` external module | Error (`unsupported_wildcard`) on the import; suppressible |
 | Cross-package wildcard import in library code | Error (`cross_package_wildcard`) on the import; suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration or import; suppressible |
@@ -403,17 +476,17 @@ refer to two different declarations is a dormant conflict: an error occurs
 only where the name is referenced:
 
 ```wesl
-import foo::*; // exports clashing_zap
-import bar::*; // exports a different clashing_zap
+import package::foo::*; // exports clashing_zap
+import package::bar::*; // exports a different clashing_zap
 
 fn main() {
-    let x = clashing_zap(); // error: ambiguous between foo::clashing_zap and bar::clashing_zap
+    let x = clashing_zap(); // error: ambiguous between the two clashing_zap declarations
 }
 ```
 
-The fix is to disambiguate with a named import (`import foo::clashing_zap;`,
-or `import foo::{clashing_zap, *};` to keep the wildcard) or an
-[inline module path](#inline-usage) (`foo::clashing_zap()`).
+The fix is to disambiguate with a named import (`import package::foo::clashing_zap;`,
+or `import package::foo::{clashing_zap, *};` to keep the wildcard) or an
+[inline declaration path](#inline-usage) (`package::foo::clashing_zap()`).
 
 ### Suppressible diagnostics
 
@@ -452,13 +525,12 @@ e.g. `diagnostic(off, wildcard_shadow);`.
 
 When a name could resolve to items at multiple precedence levels, the
 highest-precedence one wins. The table in
-[Import errors and warnings](#import-errors-and-warnings) describes whether
-such a resolution is silent, produces a warning, or produces an error.
+[Import errors and warnings](#import-errors-and-warnings) lists the overlaps
+that produce a warning or an error; other overlaps resolve silently.
 
 1. user declarations and named imports (non-wildcard)
 2. wildcard-imported names
-3. package names
-4. predeclared items (WGSL builtins)
+3. predeclared items (WGSL builtins)
 
 User declarations and named imports share the top precedence level: a conflict
 between them is an error, so at most one candidate can exist at that level.
@@ -468,8 +540,29 @@ builtins without breaking existing shaders: any name already bound at a higher
 level continues to resolve as before. Wildcard-imported names rank below user
 declarations and named imports for the analogous reason: additions to a
 `@!wildcardable` module won't silently change resolution at call sites that
-already have a local or named binding for the same name. Wildcard imports bring
-in only the imported module's top-level declarations, not package names.
+already have a local or named binding for the same name.
+
+### Module and package names form a separate namespace from declarations
+
+In a reference, a path segment followed by `::` names a module or a package,
+and a bare name refers to a declaration. So a declaration may share its name
+with a package without ambiguity:
+
+```wesl
+import light::foo;
+
+const bar: light::foo = 0; // `light::` unambiguously names the package
+
+fn light() {}              // no conflict with the package name
+```
+
+Wildcard imports preserve this separation: they bring in only the imported
+module's top-level declarations, never module or package names.
+
+Within the namespace, an import binding shadows a package with the same name:
+a first segment refers to a bound name when one is in scope, and otherwise to
+a package (see [Inline Usage](#inline-usage)). Tools may warn about the
+shadowing.
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>
@@ -493,13 +586,13 @@ This only refers to the exact module that an element is in, and not any of the p
 
 Example:
 
-```wgsl
+```wesl
 // main.wesl:
-import foo::bar;
+import package::foo::bar;
 fn main() { bar(); }
 
 // foo.wesl:
-import zig::zag;
+import package::zig::zag;
 const_assert(1 > 0); // included in link because bar is used
 fn bar() { }
 fn miz() { zag() }
@@ -511,10 +604,10 @@ fn zag() { }
 
 Example
 
-```wgsl
-import foo::bar;
+```wesl
+import package::foo::bar;
 
-// Only the foo::bar::baz module would bring in its const assertions
+// Only the package::foo::bar::baz module would bring in its const assertions
 const a: u32 = bar::baz::hello; 
 ```
 
@@ -583,7 +676,7 @@ The Bevy team, with a large shader codebase, had a few wishes
 To fully copy Rust's importing syntax, one needs something akin to a `mod` statement.
 The rules have carefully been architected to imitate the Rust style, while not requiring an explicit `mod` statement.
 
-In Rust, `use foo::bar;` could either map to "import an item called `bar` from `foo.rs`" or it could map to "import the module `foo/bar.rs`". Rust uses the explicit `mod` statement to disambiguate. We instead check for the presence of an item.
+In Rust, `use foo::bar;` could either map to "import an item called `bar` from `foo.rs`" or it could map to "import the module `foo/bar.rs`". Rust uses the explicit `mod` statement to disambiguate. We instead decide at each reference: a bare `bar` is the item, and `bar::baz` reaches into the module.
 
 ## Putting exports in comments
 This would have the advantage of letting some existing WGSL tools ignore the new syntax. For example, a WGSL formatter would not need to know about imports, and could just format the code as usual.

--- a/Imports.md
+++ b/Imports.md
@@ -281,8 +281,8 @@ compiler warnings or errors. To help mitigate this risk, WESL provides a
 designed for wildcard importing.
 
 Advanced users who wish to wildcard import from external modules not marked as
-`@wildcardable` can do so by annotating the import statement with
-`@diagnostic(off, wildcard_import)`, accepting some additional upgrade risk.
+`@wildcardable` can do so by suppressing `wildcard_import` (see
+[Suppressible diagnostics](#suppressible-diagnostics)).
 
 ```wesl
 // wildcard import from a @wildcardable external
@@ -333,7 +333,8 @@ applications.
 
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
 expected semantics that oughtn't be implicitly overridden with wildcards.
-Similarly, avoid experimental Naga/Dawn/Safari builtins.
+Similarly, avoid experimental Naga/Dawn/Safari builtins. Consumers of the
+module will see a `builtin_shadow` warning at the import site.
 - If a future WGSL update adds a conflicting builtin name, plan to update the
   `@wildcardable` module to rename the conflicting item.
 
@@ -383,6 +384,22 @@ import bar::*; // exports clashing_zap
 If `foo::clashing_zap` and `bar::clashing_zap` re-export the same item, there's
 no conflict. Otherwise the potential conflict is dormant unless `clashing_zap`
 is referenced.
+
+### Suppressible diagnostics
+
+- **`wildcard_import`** fires on a wildcard import from an external module not
+  marked `@wildcardable`. Suppress with `@diagnostic(off, wildcard_import)` on
+  the import statement to accept the upgrade risk that future versions of the
+  imported module may add conflicting names.
+
+- **`wildcard_shadow`** fires when a local declaration or named import shadows a
+  name brought in by a wildcard import. The local wins by precedence (see
+  [Scope precedence](#scope-precedence)).
+
+- **`builtin_shadow`** fires when a wildcard import shadows a WGSL builtin such
+  as `vec3` or `clamp`. Suppress at the import site if the override is
+  intentional; the suppression itself documents documents to readers that the
+  builtins have changed semantics.
 
 ### Scope precedence
 

--- a/Imports.md
+++ b/Imports.md
@@ -397,10 +397,11 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
   the import statement to accept the upgrade risk that future versions of the
   imported module may add conflicting names.
 
-- **`wildcard_shadow`** fires when a local declaration or named import shadows a
-  name brought in by a wildcard import. The local wins by precedence (see
-  [Scope precedence](#scope-precedence)). Suppress with
-  `@diagnostic(off, wildcard_shadow)` on the shadowing declaration or import.
+- **`wildcard_shadow`** fires on a local declaration or named import that
+  shadows a name brought in by a wildcard import. The local wins by precedence
+  (see [Scope precedence](#scope-precedence)). Suppress with
+  `@diagnostic(off, wildcard_shadow)` on that shadowing declaration or import
+  statement.
 
 - **`builtin_shadow`** fires in WESL publishing tools when a `@wildcardable`
   module exports an item that shadows a WGSL builtin such as `vec3` or `clamp`.

--- a/Imports.md
+++ b/Imports.md
@@ -343,7 +343,7 @@ Libraries that wildcard import from other libraries raise special concerns. If a
 user's package manager chooses a newer version of the imported-from library,
 the user may see a conflict in library code they don't expect to modify.
 
-WESL library publishing tools will address this by expanding wildcards to named
+WESL library publishing tools address this by expanding wildcards to named
 imports in the published version of the module:
 
 ```wesl
@@ -355,9 +355,6 @@ import bevy::prelude::*;
 // published artifact
 import bevy::prelude::{Color, Mesh, Transform, /* snapshot at publish time */};
 ```
-
-Until WESL packaging tools implement this expansion, library authors should
-avoid wildcard imports from external libraries they don't control.
 
 ## Import errors and warnings
 

--- a/Imports.md
+++ b/Imports.md
@@ -378,16 +378,20 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Wildcard import shadows a WGSL builtin (when name is referenced) | Warning (`builtin_shadow`) on the import; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
-more than one module:
+more than one module. The potential conflict is dormant unless the name is
+referenced; referencing it is an error:
 
 ```wesl
 import foo::*; // exports clashing_zap
-import bar::*; // exports clashing_zap
+import bar::*; // exports a different clashing_zap
+
+fn main() {
+    let x = clashing_zap(); // error: ambiguous between foo::clashing_zap and bar::clashing_zap
+}
 ```
 
-If `foo::clashing_zap` and `bar::clashing_zap` re-export the same item, there's
-no conflict. Otherwise the potential conflict is dormant unless `clashing_zap`
-is referenced.
+The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
+[inline module path](#inline-usage) (`foo::clashing_zap()`).
 
 ### Suppressible diagnostics
 

--- a/Imports.md
+++ b/Imports.md
@@ -423,8 +423,13 @@ is silent, produces a warning, or produces an error.
 5. predeclared items (WGSL builtins)
 
 Predeclared items rank lowest so that future WGSL spec revisions can add new
-builtins without breaking existing WESL code: any name already bound at a
-higher level continues to resolve as before.
+builtins without breaking existing shaders: any name already bound at a higher
+level continues to resolve as before. Wildcard-imported names rank below user
+declarations and named imports for the analogous reason: additions to a
+`@wildcardable` module won't silently change resolution at call sites that
+already have a local or named binding for the same name. Wildcard imports do not
+bring in package names (only top-level declarations of the imported module), so
+a wildcard cannot shadow a package.
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -96,7 +96,7 @@ An item import imports a single item. The item can be renamed with the `as` keyw
 
 An import collection imports multiple items, and allows for nested imports.
 
-A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported.
+A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported. A wildcard must follow a module path; a bare `import *;` is an error.
 
 WESL also extends WGSL's `global_directive` rule with a *module attribute*: a `@!`-prefixed attribute that carries module-level metadata. It is used by `@!wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata.
 

--- a/Imports.md
+++ b/Imports.md
@@ -334,9 +334,6 @@ applications.
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
 expected semantics that oughtn't be implicitly overridden with wildcards.
 Similarly, avoid experimental Naga/Dawn/Safari builtins.
-- WESL publishing tools should warn when a `@wildcardable` module exports an
-  item that shadows a WGSL builtin. Suppress with
-  `@diagnostic(off, builtin_shadow)` if the shadow is intentional.
 - If a future WGSL update adds a conflicting builtin name, plan to update the
   `@wildcardable` module to rename the conflicting item.
 
@@ -367,8 +364,7 @@ avoid wildcard imports from external libraries they don't control.
 WESL emits errors for name collisions and for external wildcards from unmarked
 modules, and warnings for shadowing that could surprise readers. Genuine
 collisions cannot be suppressed; other diagnostics are suppressible via
-`@diagnostic`. (The table below covers compile-time diagnostics; publish-time
-diagnostics are introduced in the relevant subsections.)
+`@diagnostic`.
 
 | Situation | Behavior |
 | --- | --- |
@@ -377,6 +373,7 @@ diagnostics are introduced in the relevant subsections.)
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
 | Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`); suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`); suppressible |
+| Wildcard import shadows a WGSL builtin | Warning (`builtin_shadow`); suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
 more than one module:

--- a/Imports.md
+++ b/Imports.md
@@ -86,7 +86,7 @@ import_collection:
 
 Where `translation_unit` and `ident` are defined in the WGSL grammar.
 `ident`s must not be current WGSL keywords. `ident`s also must not be 
-current WESL keywords: `as`, `import`, `module`, `package`, `super`, or `self`. 
+current WESL keywords: `as`, `import`, `package`, `super`, or `self`. 
 Reserved words that are
 not current keywords are allowed, 
 but not recommended.
@@ -98,18 +98,22 @@ An import collection imports multiple items, and allows for nested imports.
 
 A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported.
 
-WESL also extends WGSL's `global_directive` rule with a `module_declaration` form, used by `@wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata. `attribute` is the WGSL attribute rule.
+WESL also extends WGSL's `global_directive` rule with a *module attribute*: a `@!`-prefixed attribute that carries module-level metadata. It is used by `@!wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata.
 
 ```ebnf
 global_directive:
 | ... // existing WGSL forms
-| module_declaration
+| module_attribute_directive
 
-module_declaration:
-| attribute* 'module' ';'
+module_attribute_directive:
+| '@' '!' ident_pattern_token argument_expression_list? ';'
 ```
 
-A file may have at most one `module` declaration.
+A module attribute is written like a WGSL `attribute` with a `!` immediately
+after the `@`, and is terminated with `;`; `ident_pattern_token` and
+`argument_expression_list` are the WGSL rules. Like other global directives,
+module attributes appear after any imports and before any global declarations,
+and apply to the module they appear in.
 
 ### Import resolution algorithm
 
@@ -271,21 +275,21 @@ scope.
 Users can wildcard import:
 - from any other module in the local package.
 - from any external library module where the library author has added a
-  `@wildcardable` annotation.
+  `@!wildcardable` annotation.
 
 Wildcard importing brings some stability risk when the imported module adds to
 its API. The newly introduced names may conflict with other names in the
 importer's namespace (from local definitions and other imports), leading to
 compiler warnings or errors. To help mitigate this risk, WESL provides a
-`@wildcardable` annotation that library authors can place on modules that are
+`@!wildcardable` annotation that library authors can place on modules that are
 designed for wildcard importing.
 
 Advanced users who wish to wildcard import from external modules not marked as
-`@wildcardable` can do so by suppressing `wildcard_import` (see
+`@!wildcardable` can do so by suppressing `wildcard_import` (see
 [Suppressible diagnostics](#suppressible-diagnostics)).
 
 ```wesl
-// wildcard import from a @wildcardable external
+// wildcard import from a @!wildcardable external
 import bevy::prelude::*;
 import wgsl_test::expect::*;
 
@@ -294,37 +298,33 @@ import package::utils::*;
 import super::fun::*;
 ```
 
-### `@wildcardable` annotation
+### `@!wildcardable` annotation
 
 Library authors mark modules they intend for library consumers to wildcard
-import with `@wildcardable module;`:
+import with the `@!wildcardable;` module attribute (see [Grammar](#grammar)):
 
 ```wesl
 // math.wesl  (in a library)
-@wildcardable module;
+@!wildcardable;
 
 fn dot2(a: vec2f, b: vec2f) -> f32 { return a.x*b.x + a.y*b.y; }
 fn cross2(a: vec2f, b: vec2f) -> f32 { return a.x*b.y - a.y*b.x; }
 ```
 
-`@wildcardable` is an attribute on a module declaration (see [Grammar](#grammar)).
-The module declaration must appear after any imports and before any global
-declarations, and applies only to the module it appears in.
+### Recommendations for `@!wildcardable` modules
 
-### Recommendations for `@wildcardable` modules
-
-Because every name in a `@wildcardable` module is a potential collision in
+Because every name in a `@!wildcardable` module is a potential collision in
 importer code, library authors should curate these modules carefully.
 
-**Add hesitantly.** Additions to a `@wildcardable` module are semver minor
+**Add hesitantly.** Additions to a `@!wildcardable` module are semver minor
 version bumps but can break users who have local declarations or import other
-`@wildcardable` modules.
+`@!wildcardable` modules.
 - **Bundle** additions into a major release when one is upcoming.
 - **Document** additions clearly in changelogs so downstream users debugging
   unexpected name resolution can trace them.
 
 **Compose with re-exports.** See [Re-exports](#re-exports) (TBD) to collect
-items from other modules into a single `@wildcardable` module for user
+items from other modules into a single `@!wildcardable` module for user
 convenience.
 
 **Avoid generic names.** Prefer domain-specific names. Common names like
@@ -334,11 +334,11 @@ applications.
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
 expected semantics that oughtn't be implicitly overridden with wildcards.
 Similarly, avoid experimental Naga/Dawn/Safari builtins.
-- WESL publishing tools should warn when a `@wildcardable` module exports an
+- WESL publishing tools should warn when a `@!wildcardable` module exports an
   item that shadows a WGSL builtin. Suppress with
   `@diagnostic(off, builtin_shadow)` in the module if the shadow is intentional.
 - If a future WGSL update adds a conflicting builtin name, plan to update the
-  `@wildcardable` module to rename the conflicting item.
+  `@!wildcardable` module to rename the conflicting item.
 
 ### Library-to-library wildcard imports
 
@@ -371,7 +371,7 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Local declaration conflicts with named import | Error |
 | Named import conflicts with named import | Error |
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
-| Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`) on the import; suppressible |
+| Wildcard import from a non-`@!wildcardable` external module | Error (`wildcard_import`) on the import; suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
@@ -393,7 +393,7 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
 ### Suppressible diagnostics
 
 - **`wildcard_import`** fires on a wildcard import from an external module not
-  marked `@wildcardable`. Suppress with `@diagnostic(off, wildcard_import)` on
+  marked `@!wildcardable`. Suppress with `@diagnostic(off, wildcard_import)` on
   the import statement to accept the upgrade risk that future versions of the
   imported module may add conflicting names.
 
@@ -403,7 +403,7 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
   `@diagnostic(off, wildcard_shadow)` on that shadowing declaration or import
   statement.
 
-- **`builtin_shadow`** fires in WESL publishing tools when a `@wildcardable`
+- **`builtin_shadow`** fires in WESL publishing tools when a `@!wildcardable`
   module exports an item that shadows a WGSL builtin such as `vec3` or `clamp`.
   Suppress with `@diagnostic(off, builtin_shadow)` in the module if the override
   is intentional.
@@ -424,7 +424,7 @@ Predeclared items rank lowest so that future WGSL spec revisions can add new
 builtins without breaking existing shaders: any name already bound at a higher
 level continues to resolve as before. Wildcard-imported names rank below user
 declarations and named imports for the analogous reason: additions to a
-`@wildcardable` module won't silently change resolution at call sites that
+`@!wildcardable` module won't silently change resolution at call sites that
 already have a local or named binding for the same name. Wildcard imports do not
 bring in package names (only top-level declarations of the imported module), so
 a wildcard cannot shadow a package.

--- a/Imports.md
+++ b/Imports.md
@@ -399,16 +399,9 @@ is silent, produces a warning, or produces an error.
 4. package names
 5. predeclared items (WGSL builtins)
 
-Package names can shadow predeclared items, but we recommend that authors avoid
-doing that.
-
-## Forward compatibility with WGSL predeclared identifiers
-
-Predeclared items have the lowest priority in scope resolution (see
-[Scope precedence](#scope-precedence)). WGSL can add new predeclared items in
-future spec revisions without breaking existing WESL code: any name already
-bound by a user declaration, named import, wildcard import, or package continues
-to resolve as before.
+Predeclared items rank lowest so that future WGSL spec revisions can add new
+builtins without breaking existing WESL code: any name already bound at a
+higher level continues to resolve as before.
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -474,19 +474,19 @@ This only refers to the exact module that an element is in, and not any of the p
 Example:
 
 ```wgsl
-​​​​// main.wesl:
-​​​​import foo::bar;
-​​​​fn main() { bar(); }
+// main.wesl:
+import foo::bar;
+fn main() { bar(); }
 
-​​​​// foo.wesl:
-​​​​import zig::zag;
-​​​​const_assert(1 > 0); // included in link because bar is used
-​​​​fn bar() { }
-​​​​fn miz() { zag() }
+// foo.wesl:
+import zig::zag;
+const_assert(1 > 0); // included in link because bar is used
+fn bar() { }
+fn miz() { zag() }
 
-​​​​// zig.wesl:
-​​​​const_assert(2 < 0); // not included in link
-​​​​fn zag() { }
+// zig.wesl:
+const_assert(2 < 0); // not included in link
+fn zag() { }
 ```
 
 Example

--- a/Imports.md
+++ b/Imports.md
@@ -70,7 +70,7 @@ translation_unit:
 | import_statement* global_directive* global_decl* 
 
 import_statement:  
-| 'import' import_relative? (import_collection | import_path_or_item) ';'  
+| attribute* 'import' import_relative? (import_collection | import_path_or_item) ';'  
 
 import_relative:
 | 'package' '::' | 'super' '::' ('super' '::')*
@@ -86,7 +86,7 @@ import_collection:
 
 Where `translation_unit` and `ident` are defined in the WGSL grammar.
 `ident`s must not be current WGSL keywords. `ident`s also must not be 
-current WESL keywords: `as`, `import`, `package`, `super`, or `self`. 
+current WESL keywords: `as`, `import`, `module`, `package`, `super`, or `self`. 
 Reserved words that are
 not current keywords are allowed, 
 but not recommended.
@@ -98,18 +98,16 @@ An import collection imports multiple items, and allows for nested imports.
 
 A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported.
 
-WESL also extends WGSL's `global_directive` rule with a `module_attribute` form (used by `@wildcardable`; see [Wildcard imports](#wildcard-imports)):
+WESL also extends WGSL's `global_directive` rule with a `module_declaration` form, used by `@wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata. `attribute` is the WGSL attribute rule.
 
 ```ebnf
 global_directive:
 | ... // existing WGSL forms
-| module_attribute
+| module_declaration
 
-module_attribute:
-| '@' ident ';'
+module_declaration:
+| attribute* 'module' ';'
 ```
-
-The `@` prefix avoids conflict with WGSL identifiers.
 
 ### Import resolution algorithm
 
@@ -271,7 +269,7 @@ scope.
 Users can wildcard import:
 - from any other module in the local package.
 - from any external library module where the library author has added a
-  `@wildcardable` directive.
+  `@wildcardable` annotation.
 
 Wildcard importing brings some stability risk when the imported module adds to
 its API. The newly introduced names may conflict with other names in the
@@ -294,22 +292,22 @@ import package::utils::*;
 import super::fun::*;
 ```
 
-### `@wildcardable` directive
+### `@wildcardable` annotation
 
 Library authors mark modules they intend for library consumers to wildcard
-import with `@wildcardable`:
+import with `@wildcardable module;`:
 
 ```wesl
 // math.wesl  (in a library)
-@wildcardable;
+@wildcardable module;
 
 fn dot2(a: vec2f, b: vec2f) -> f32 { return a.x*b.x + a.y*b.y; }
 fn cross2(a: vec2f, b: vec2f) -> f32 { return a.x*b.y - a.y*b.x; }
 ```
 
-`@wildcardable` is a module attribute (see [Grammar](#grammar)). It must
-appear after any imports and before any global declarations, and applies only
-to the module it appears in.
+`@wildcardable` is an attribute on a module declaration (see [Grammar](#grammar)).
+The module declaration must appear after any imports and before any global
+declarations, and applies only to the module it appears in.
 
 ### Recommendations for `@wildcardable` modules
 

--- a/Imports.md
+++ b/Imports.md
@@ -336,9 +336,7 @@ expected semantics that oughtn't be implicitly overridden with wildcards.
 Similarly, avoid experimental Naga/Dawn/Safari builtins.
 - WESL publishing tools should warn when a `@wildcardable` module exports an
   item that shadows a WGSL builtin. Suppress with
-  `@diagnostic(off, builtin_shadow)` if the shadow is intentional.
-- Consumers of the module will also see a `builtin_shadow` warning at the
-  import site.
+  `@diagnostic(off, builtin_shadow)` in the module if the shadow is intentional.
 - If a future WGSL update adds a conflicting builtin name, plan to update the
   `@wildcardable` module to rename the conflicting item.
 
@@ -375,7 +373,6 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
 | Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`); suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`); suppressible |
-| Wildcard import shadows a WGSL builtin (when name is referenced) | Warning (`builtin_shadow`) on the import; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
 more than one module. The potential conflict is dormant unless the name is
@@ -402,13 +399,13 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
 
 - **`wildcard_shadow`** fires when a local declaration or named import shadows a
   name brought in by a wildcard import. The local wins by precedence (see
-  [Scope precedence](#scope-precedence)).
+  [Scope precedence](#scope-precedence)). Suppress with
+  `@diagnostic(off, wildcard_shadow)` on the shadowing declaration or import.
 
-- **`builtin_shadow`** fires on a wildcard import when a referenced name in the
-  module resolves to a wildcard-imported item that shadows a WGSL builtin such
-  as `vec3` or `clamp`. Suppress at the import site if the override is
-  intentional; the suppression itself documents to readers that the builtins
-  have changed semantics.
+- **`builtin_shadow`** fires in WESL publishing tools when a `@wildcardable`
+  module exports an item that shadows a WGSL builtin such as `vec3` or `clamp`.
+  Suppress with `@diagnostic(off, builtin_shadow)` in the module if the override
+  is intentional.
 
 ## Scope precedence
 

--- a/Imports.md
+++ b/Imports.md
@@ -401,7 +401,7 @@ is referenced.
   intentional; the suppression itself documents documents to readers that the
   builtins have changed semantics.
 
-### Scope precedence
+## Scope precedence
 
 When a name could resolve to items at multiple precedence levels, the
 highest-precedence one wins. The table above describes whether such a resolution

--- a/Imports.md
+++ b/Imports.md
@@ -268,10 +268,21 @@ Basic linker implementations do not need to check for this. Generating broken co
 Wildcard imports bring all items from another module into the importing module's
 scope.
 
-By default, users can wildcard import:
-- from any other module in the local package, and
+Users can wildcard import:
+- from any other module in the local package.
 - from any external library module where the library author has added a
   `@wildcardable` directive.
+
+Wildcard importing brings some stability risk when the imported module adds to
+its API. The newly introduced names may conflict with other names in the
+importer's namespace (from local definitions and other imports), leading to
+compiler warnings or errors. To help mitigate this risk, WESL provides a
+`@wildcardable` annotation that library authors can place on modules that are
+designed for wildcard importing.
+
+Advanced users who wish to wildcard import from external modules not marked as
+`@wildcardable` can do so by annotating the import statement with
+`@diagnostic(off, wildcard_import)`, accepting some additional upgrade risk.
 
 ```wesl
 // wildcard import from a @wildcardable external
@@ -282,11 +293,6 @@ import wgsl_test::prelude::*;
 import package::utils::*;
 import super::fun::*;
 ```
-
-Advanced users who wish to import from external package modules that are not
-marked as `@wildcardable` can annotate the import statement with
-`@diagnostic(off, wildcard_import)`, accepting the increased risk of name
-clashes if the upstream module adds items in a future version.
 
 ### `@wildcardable` directive
 
@@ -307,20 +313,19 @@ to the module it appears in.
 
 ### Recommendations for `@wildcardable` modules
 
-**Curate carefully.** A `@wildcardable` module is a public API contract in a
-shared namespace. Every item you add is one your downstream users may collide
-with.
+Because every name in a `@wildcardable` module is a potential collision in
+importer code, library authors should curate these modules carefully.
+
+**Add hesitantly.** Additions to a `@wildcardable` module are semver minor
+version bumps but can break users who have local declarations or import other
+`@wildcardable` modules.
+- **Bundle** additions into a major release when one is upcoming.
+- **Document** additions clearly in changelogs so downstream users debugging
+  unexpected name resolution can trace them.
 
 **Compose with re-exports.** See [Re-exports](#re-exports) (TBD) to collect
 items from other modules into a single `@wildcardable` module for user
 convenience.
-
-**Add hesitantly.** Additions to a `@wildcardable` module are semver minor
-version bumps but can break users who have local declarations or import other
-preludes.
-- **Bundle** additions into a major release when one is upcoming.
-- **Document** additions clearly in changelogs so downstream users debugging
-  unexpected name resolution can trace them.
 
 **Avoid generic names.** Prefer domain-specific names. Common names like
 `Buffer`, `Config`, `Result`, `Vec`, etc. are more likely to collide with user

--- a/Imports.md
+++ b/Imports.md
@@ -334,9 +334,8 @@ applications.
 **Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
 expected semantics that oughtn't be implicitly overridden with wildcards.
 Similarly, avoid experimental Naga/Dawn/Safari builtins.
-- WESL publishing tools should warn when a `@!wildcardable` module exports an
-  item that shadows a WGSL builtin. Suppress with
-  `@diagnostic(off, builtin_shadow)` in the module if the shadow is intentional.
+- The `builtin_shadow` diagnostic flags this (see
+  [Suppressible diagnostics](#suppressible-diagnostics)).
 - If a future WGSL update adds a conflicting builtin name, plan to update the
   `@!wildcardable` module to rename the conflicting item.
 
@@ -346,8 +345,15 @@ Libraries that wildcard import from other libraries raise special concerns. If a
 user's package manager chooses a newer version of the imported-from library,
 the user may see a conflict in library code they don't expect to modify.
 
-WESL library publishing tools address this by expanding wildcards to named
-imports in the published version of the module:
+Cross-package wildcard imports in library code
+trigger the `library_wildcard` diagnostic, a suppressible error. Library
+authors can suppress the diagnostic with
+`@diagnostic(off, library_wildcard)` on the import statement, e.g. when
+wildcard importing from external packages they control.
+
+**Optional: publish-time wildcard expansion.** Library publishing tools may
+also offer to expand wildcards to named imports in the published version of a
+module, snapshotting the names at publish time:
 
 ```wesl
 // source
@@ -358,6 +364,9 @@ import bevy::prelude::*;
 // published artifact
 import bevy::prelude::{Color, Mesh, Transform, /* snapshot at publish time */};
 ```
+
+Expansion pins the imported names so that a newer version of the imported-from
+library can't introduce conflicts into already-published code.
 
 ## Import errors and warnings
 
@@ -372,11 +381,15 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Named import conflicts with named import | Error |
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
 | Wildcard import from a non-`@!wildcardable` external module | Error (`wildcard_import`) on the import; suppressible |
-| Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration; suppressible |
+| Cross-package wildcard import in library code | Error (`library_wildcard`) on the import; suppressible |
+| Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration or import; suppressible |
+| `@!wildcardable` module exports an item shadowing a WGSL builtin | Warning (`builtin_shadow`) in the exporting module; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
-more than one module. The potential conflict is dormant unless the name is
-referenced; referencing it is an error:
+more than one module. If every wildcard resolves the name to the same
+declaration, references are unambiguous and no error occurs. A name that could
+refer to two different declarations is a dormant conflict: an error occurs
+only where the name is referenced:
 
 ```wesl
 import foo::*; // exports clashing_zap
@@ -395,39 +408,48 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
 - **`wildcard_import`** fires on a wildcard import from an external module not
   marked `@!wildcardable`. Suppress with `@diagnostic(off, wildcard_import)` on
   the import statement to accept the upgrade risk that future versions of the
-  imported module may add conflicting names.
+  imported module may add conflicting names. The suppression has no effect on
+  an import from a `@!wildcardable` module, where the diagnostic never fires.
 
-- **`wildcard_shadow`** fires on a local declaration or named import that
-  shadows a name brought in by a wildcard import. The local wins by precedence
-  (see [Scope precedence](#scope-precedence)). Suppress with
-  `@diagnostic(off, wildcard_shadow)` on that shadowing declaration or import
-  statement.
+- **`wildcard_shadow`** is a warning that fires on a local declaration or named
+  import that shadows a name brought in by a wildcard import. The shadowing is
+  allowed: the local declaration or named import wins by precedence
+  (see [Scope precedence](#scope-precedence)). Suppressing the warning with
+  `@diagnostic(off, wildcard_shadow)` on the shadowing declaration or import
+  statement changes only the reporting, not the resolution.
 
-- **`builtin_shadow`** fires in WESL publishing tools when a `@!wildcardable`
-  module exports an item that shadows a WGSL builtin such as `vec3` or `clamp`.
-  Suppress with `@diagnostic(off, builtin_shadow)` in the module if the override
-  is intentional.
+- **`library_wildcard`** is a suppressible error that fires on a cross-package
+  wildcard import in library code (see
+  [Library-to-library wildcard imports](#library-to-library-wildcard-imports)).
+  Suppress with `@diagnostic(off, library_wildcard)` on the import statement.
+
+- **`builtin_shadow`** fires on a `@!wildcardable` module that exports an item
+  shadowing a WGSL builtin such as `vec3` or `clamp`. Suppress with
+  `@diagnostic(off, builtin_shadow)` in the module if the override is
+  intentional.
 
 ## Scope precedence
 
 When a name could resolve to items at multiple precedence levels, the
-highest-precedence one wins. The table above describes whether such a resolution
-is silent, produces a warning, or produces an error.
+highest-precedence one wins. The table in
+[Import errors and warnings](#import-errors-and-warnings) describes whether
+such a resolution is silent, produces a warning, or produces an error.
 
-1. user declarations
-2. named imports (non-wildcard)
-3. wildcard-imported names
-4. package names
-5. predeclared items (WGSL builtins)
+1. user declarations and named imports (non-wildcard)
+2. wildcard-imported names
+3. package names
+4. predeclared items (WGSL builtins)
+
+User declarations and named imports share the top precedence level: a conflict
+between them is an error, so at most one candidate can exist at that level.
 
 Predeclared items rank lowest so that future WGSL spec revisions can add new
 builtins without breaking existing shaders: any name already bound at a higher
 level continues to resolve as before. Wildcard-imported names rank below user
 declarations and named imports for the analogous reason: additions to a
 `@!wildcardable` module won't silently change resolution at call sites that
-already have a local or named binding for the same name. Wildcard imports do not
-bring in package names (only top-level declarations of the imported module), so
-a wildcard cannot shadow a package.
+already have a local or named binding for the same name. Wildcard imports bring
+in only the imported module's top-level declarations, not package names.
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -23,8 +23,9 @@ import my::geom::sphere::{ draw, default_radius as foobar };
 // Imports a whole module. Use it with `bevy_ui::name`
 import bevy_ui;
 
-// Import all items defined in the bevy prelude
+// Import all items from another module
 import bevy::prelude::*;
+import wgsl_test::prelude::*;
 ```
 
 These can then be used anywhere in the source code.
@@ -95,7 +96,20 @@ An item import imports a single item. The item can be renamed with the `as` keyw
 
 An import collection imports multiple items, and allows for nested imports.
 
-A wildcard import imports all items from a module, but does not import further modules.
+A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported.
+
+WESL also extends WGSL's `global_directive` rule with a `module_attribute` form (used by `@wildcardable`; see [Wildcard imports](#wildcard-imports)):
+
+```ebnf
+global_directive:
+| ... // existing WGSL forms
+| module_attribute
+
+module_attribute:
+| '@' ident ';'
+```
+
+The `@` prefix avoids conflict with WGSL identifiers.
 
 ### Import resolution algorithm
 
@@ -128,9 +142,7 @@ Then, one iterates over each segment from left to right, and looks it up one by 
 To get an absolute path to a module, one follows the algorithm above. In step 1, one takes the known absolute path of the `super` module, or the package.
 The absolute path of the `super` module is always known, since the first loaded WESL file must always be the root module, and children are only discovered from there.
 
-Once the import has been resolved, the last segment, or its alias, is brought into scope.
-
-The order of the scopes is "user declarations and imported items > wildcard import > package names > predeclared items".
+Once the import has been resolved, the last segment, or its `as` alias, is brought into scope.
 
 
 ### Example
@@ -251,81 +263,150 @@ const b = a + 1;
 
 Basic linker implementations do not need to check for this. Generating broken code and letting the underlying shader compiler throw an error is fine.
 
-## Wildcard Imports
+## Wildcard imports
 
-Wildcard imports are used to import a whole set of items into the current module. They are lower priority than local names and explicit imports to reduce the chance of breaking changes if the wildcard-imported module changes. Wildcard imported modules are eagerly loaded, since they need to be checked before accessing any predeclared items.
+Wildcard imports bring all items from another module into the importing module's
+scope.
 
-When multiple wildcard imports are used, name clashes are possible.
-
-```wesl
-import foo::*; // exports clashing_name
-import bar::*; // exports clashing_name
-```
-
-The name clash is ignored until the item is used.
-TODO: Or should it immediately result in a warning, even if the variables are unused?
-
-### Diagnostics for best practices
-
-Many ecosystems rely on semantic versioning for updating libraries. This applies to both direct and transitive dependencies. Updating to the latest patch releases should be easy and safe. 
-
-Library authors generally expect that adding a new item is not a breaking change. Wildcard imports that result in name clashes are a surprising edge case. Therefore, we want to reduce the risk of accidental name clashes.
-
-Name clashes can happen either in user code or in library code. If it happens in library code, it can be significantly harder to resolve the issue. 
-
-A secondary, similar issue is that wildcards can result in accidental shadowing of predeclared identifiers. 
-One especially insideous scenario is when user code targets an unstable Naga feature.
+By default, users can wildcard import:
+- from any other module in the local package, and
+- from any external library module where the library author has added a
+  `@wildcardable` directive.
 
 ```wesl
-import my_lib::*;
+// wildcard import from a @wildcardable external
+import bevy::prelude::*;
+import wgsl_test::prelude::*;
 
-const x = unstable_thing();
+// wildcard import from within the local package
+import package::utils::*;
+import super::fun::*;
 ```
 
-Then, a library which does not know about the Naga feature could add an item with the same name. 
+Advanced users who wish to import from external package modules that are not
+marked as `@wildcardable` can annotate the import statement with
+`@diagnostic(off, wildcard_import)`, accepting the increased risk of name
+clashes if the upstream module adds items in a future version.
 
-To reduce the odds of these cases, we recommend the following diagnostics.
+### `@wildcardable` directive
 
-1. Emit a warning [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) named `builtin_shadowing` if an top level item is declared that is known to conflict with a predeclared identifier. This also helps in the non-library case.
-
-2. Emit a warning [diagnostic](https://www.w3.org/TR/WGSL/#diagnostics) named `wildcard_import` if there are multiple wildcard imports from libraries and at least one is not designed for wildcards.
-
-For this, we distinguish between modules that were designed for wildcard imports and modules that were not. When the library module is called `prelude`, it is a module designed for wildcards. Adding a new item to it is a semver breaking change. Therefore, wildcard importing from it is always allowed. (When we add exports, we will make this controllable instead of only giving special treatment to the `prelude`.)
-
-Other library modules may cause issues and should not be combined with other wildcard imports.
-
-Modules in the same package can always be wildcard imported. Changing your own code has no impact on semver.
-
-Examples
+Library authors mark modules they intend for library consumers to wildcard
+import with `@wildcardable`:
 
 ```wesl
-// Allowed, since it is the only import in the current module
-import lygia::math::*; 
+// math.wesl  (in a library)
+@wildcardable;
+
+fn dot2(a: vec2f, b: vec2f) -> f32 { return a.x*b.x + a.y*b.y; }
+fn cross2(a: vec2f, b: vec2f) -> f32 { return a.x*b.y - a.y*b.x; }
+```
+
+`@wildcardable` is a module attribute (see [Grammar](#grammar)). It must
+appear after any imports and before any global declarations, and applies only
+to the module it appears in.
+
+### Recommendations for `@wildcardable` modules
+
+**Curate carefully.** A `@wildcardable` module is a public API contract in a
+shared namespace. Every item you add is one your downstream users may collide
+with.
+
+**Compose with re-exports.** See [Re-exports](#re-exports) (TBD) to collect
+items from other modules into a single `@wildcardable` module for user
+convenience.
+
+**Add hesitantly.** Additions to a `@wildcardable` module are semver minor
+version bumps but can break users who have local declarations or import other
+preludes.
+- **Bundle** additions into a major release when one is upcoming.
+- **Document** additions clearly in changelogs so downstream users debugging
+  unexpected name resolution can trace them.
+
+**Avoid generic names.** Prefer domain-specific names. Common names like
+`Buffer`, `Config`, `Result`, `Vec`, etc. are more likely to collide with user
+applications.
+
+**Don't shadow WGSL builtins.** Names like `vec3`, `clamp`, `inverseSqrt` have
+expected semantics that oughtn't be implicitly overridden with wildcards.
+Similarly, avoid experimental Naga/Dawn/Safari builtins.
+- WESL publishing tools should warn when a `@wildcardable` module exports an
+  item that shadows a WGSL builtin. Suppress with
+  `@diagnostic(off, builtin_shadow)` if the shadow is intentional.
+- If a future WGSL update adds a conflicting builtin name, plan to update the
+  `@wildcardable` module to rename the conflicting item.
+
+### Library-to-library wildcard imports
+
+Libraries that wildcard import from other libraries raise special concerns. If a
+user's package manager chooses a newer version of the imported-from library,
+the user may see a conflict in library code they don't expect to modify.
+
+WESL library publishing tools will address this by expanding wildcards to named
+imports in the published version of the module:
+
+```wesl
+// source
+import bevy::prelude::*;
 ```
 
 ```wesl
-// Allowed, since it is designed for wildcards
-import bevy::color::prelude::*; 
-
-// Allowed, same package
-import package::utils::*; 
-
-// Requires opt-in
-@diagnostic(off, wildcard_import) 
-import lygia::math::*; 
+// published artifact
+import bevy::prelude::{Color, Mesh, Transform, /* snapshot at publish time */};
 ```
 
-### Modeling the WGSL predeclared identifiers
+Until WESL packaging tools implement this expansion, library authors should
+avoid wildcard imports from external libraries they don't control.
 
-One mental model for WGSL predeclared identifiers is that they're a wildcard import, which is implicitly added to every WGSL file. 
+## Import errors and warnings
+
+WESL emits errors for name collisions and for external wildcards from unmarked
+modules, and warnings for shadowing that could surprise readers. Genuine
+collisions cannot be suppressed; other diagnostics are suppressible via
+`@diagnostic`. (The table below covers compile-time diagnostics; publish-time
+diagnostics are introduced in the relevant subsections.)
+
+| Situation | Behavior |
+| --- | --- |
+| Local declaration conflicts with named import | Error |
+| Named import conflicts with named import | Error |
+| Wildcard import conflicts with wildcard import (when name is referenced) | Error |
+| Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`); suppressible |
+| Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`); suppressible |
+
+When multiple wildcard imports are in scope, the same name may be exported by
+more than one module:
 
 ```wesl
-// imports all the predeclared identifiers
-import all_wgsl_items::*;
+import foo::*; // exports clashing_zap
+import bar::*; // exports clashing_zap
 ```
 
-This wildcard import has a strictly lower priority than all other wildcard imports. This lets WGSL add more predeclared items without breaking existing WESL code. Package names can also shadow predeclared items, but we recommend that authors avoid doing that.
+If `foo::clashing_zap` and `bar::clashing_zap` re-export the same item, there's
+no conflict. Otherwise the potential conflict is dormant unless `clashing_zap`
+is referenced.
 
+### Scope precedence
+
+When a name could resolve to items at multiple precedence levels, the
+highest-precedence one wins. The table above describes whether such a resolution
+is silent, produces a warning, or produces an error.
+
+1. user declarations
+2. named imports (non-wildcard)
+3. wildcard-imported names
+4. package names
+5. predeclared items (WGSL builtins)
+
+Package names can shadow predeclared items, but we recommend that authors avoid
+doing that.
+
+## Forward compatibility with WGSL predeclared identifiers
+
+Predeclared items have the lowest priority in scope resolution (see
+[Scope precedence](#scope-precedence)). WGSL can add new predeclared items in
+future spec revisions without breaking existing WESL code: any name already
+bound by a user declaration, named import, wildcard import, or package continues
+to resolve as before.
 
 ## Directives
 Under discussion, see: <https://github.com/wgsl-tooling-wg/wesl-spec/issues/71>

--- a/Imports.md
+++ b/Imports.md
@@ -96,7 +96,7 @@ An item import imports a single item. The item can be renamed with the `as` keyw
 
 An import collection imports multiple items, and allows for nested imports.
 
-A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported. A wildcard must follow a module path; a bare `import *;` is an error.
+A wildcard import imports all top-level declarations from a module. Submodule names and submodule contents are not imported. A wildcard must follow a module path; a bare `import *;` is an error. A wildcard may also appear as a member of an import collection, applying to the module path before the braces (see [Import resolution algorithm](#import-resolution-algorithm)).
 
 WESL also extends WGSL's `global_directive` rule with a *module attribute*: a `@!`-prefixed attribute that carries module-level metadata. It is used by `@!wildcardable` (see [Wildcard imports](#wildcard-imports)) and reserved for future module-level metadata.
 
@@ -125,6 +125,17 @@ import a::b;
 import a::c::d;
 import a::c::e as f;
 ```
+
+A wildcard may appear as a member of an import collection:
+`import foo::{a::b, *};` becomes
+
+```wesl
+import foo::a::b;
+import foo::*;
+```
+
+The wildcard imports only `foo`'s own top-level declarations: the sibling
+branch reaching into submodule `foo::a` doesn't widen it.
 
 Then, one iterates over each segment from left to right, and looks it up one by one.
 
@@ -285,7 +296,7 @@ compiler warnings or errors. To help mitigate this risk, WESL provides a
 designed for wildcard importing.
 
 Advanced users who wish to wildcard import from external modules not marked as
-`@!wildcardable` can do so by suppressing `wildcard_import` (see
+`@!wildcardable` can do so by suppressing `unsupported_wildcard` (see
 [Suppressible diagnostics](#suppressible-diagnostics)).
 
 ```wesl
@@ -346,9 +357,9 @@ user's package manager chooses a newer version of the imported-from library,
 the user may see a conflict in library code they don't expect to modify.
 
 Cross-package wildcard imports in library code
-trigger the `library_wildcard` diagnostic, a suppressible error. Library
+trigger the `cross_package_wildcard` diagnostic, a suppressible error. Library
 authors can suppress the diagnostic with
-`@diagnostic(off, library_wildcard)` on the import statement, e.g. when
+`@diagnostic(off, cross_package_wildcard)` on the import statement, e.g. when
 wildcard importing from external packages they control.
 
 **Optional: publish-time wildcard expansion.** Library publishing tools may
@@ -370,8 +381,8 @@ library can't introduce conflicts into already-published code.
 
 ## Import errors and warnings
 
-WESL emits errors for name collisions and for external wildcards from unmarked
-modules, and warnings for shadowing that could surprise readers. Genuine
+WESL emits errors for name collisions and for unsupported wildcard imports,
+and warnings for shadowing that could surprise readers. Genuine
 collisions cannot be suppressed; other diagnostics are suppressible via
 `@diagnostic`.
 
@@ -380,10 +391,10 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Local declaration conflicts with named import | Error |
 | Named import conflicts with named import | Error |
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
-| Wildcard import from a non-`@!wildcardable` external module | Error (`wildcard_import`) on the import; suppressible |
-| Cross-package wildcard import in library code | Error (`library_wildcard`) on the import; suppressible |
+| Wildcard import from a non-`@!wildcardable` external module | Error (`unsupported_wildcard`) on the import; suppressible |
+| Cross-package wildcard import in library code | Error (`cross_package_wildcard`) on the import; suppressible |
 | Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration or import; suppressible |
-| `@!wildcardable` module exports an item shadowing a WGSL builtin | Warning (`builtin_shadow`) in the exporting module; suppressible |
+| `@!wildcardable` module exports an item shadowing a WGSL builtin | Warning (`builtin_shadow`) on the shadowing declaration; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
 more than one module. If every wildcard resolves the name to the same
@@ -400,16 +411,23 @@ fn main() {
 }
 ```
 
-The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
+The fix is to disambiguate with a named import (`import foo::clashing_zap;`,
+or `import foo::{clashing_zap, *};` to keep the wildcard) or an
 [inline module path](#inline-usage) (`foo::clashing_zap()`).
 
 ### Suppressible diagnostics
 
-- **`wildcard_import`** fires on a wildcard import from an external module not
-  marked `@!wildcardable`. Suppress with `@diagnostic(off, wildcard_import)` on
-  the import statement to accept the upgrade risk that future versions of the
-  imported module may add conflicting names. The suppression has no effect on
-  an import from a `@!wildcardable` module, where the diagnostic never fires.
+Each diagnostic below can be suppressed at the site indicated with a
+`@diagnostic` attribute, or module-wide with WGSL's
+[global diagnostic directive](https://www.w3.org/TR/WGSL/#global-diagnostic-directive),
+e.g. `diagnostic(off, wildcard_shadow);`.
+
+- **`unsupported_wildcard`** fires on a wildcard import from an external module
+  that doesn't support wildcard import (not marked `@!wildcardable`). Suppress
+  with `@diagnostic(off, unsupported_wildcard)` on the import statement to
+  accept the upgrade risk that future versions of the imported module may add
+  conflicting names. The suppression has no effect on an import from a
+  `@!wildcardable` module, where the diagnostic never fires.
 
 - **`wildcard_shadow`** is a warning that fires on a local declaration or named
   import that shadows a name brought in by a wildcard import. The shadowing is
@@ -418,15 +436,17 @@ The fix is to disambiguate with a named import (`import foo::clashing_zap;`) or
   `@diagnostic(off, wildcard_shadow)` on the shadowing declaration or import
   statement changes only the reporting, not the resolution.
 
-- **`library_wildcard`** is a suppressible error that fires on a cross-package
-  wildcard import in library code (see
+- **`cross_package_wildcard`** is a suppressible error that fires on a
+  cross-package wildcard import in library code (see
   [Library-to-library wildcard imports](#library-to-library-wildcard-imports)).
-  Suppress with `@diagnostic(off, library_wildcard)` on the import statement.
+  Suppress with `@diagnostic(off, cross_package_wildcard)` on the import
+  statement.
 
-- **`builtin_shadow`** fires on a `@!wildcardable` module that exports an item
-  shadowing a WGSL builtin such as `vec3` or `clamp`. Suppress with
-  `@diagnostic(off, builtin_shadow)` in the module if the override is
-  intentional.
+- **`builtin_shadow`** is a warning that fires in a `@!wildcardable` module,
+  on a top-level declaration whose name shadows a WGSL builtin such as `vec3`
+  or `clamp`, whether or not any module wildcard imports it. Suppress with
+  `@diagnostic(off, builtin_shadow)` on the offending declaration if the
+  override is intentional.
 
 ## Scope precedence
 

--- a/Imports.md
+++ b/Imports.md
@@ -25,7 +25,7 @@ import bevy_ui;
 
 // Import all items from another module
 import bevy::prelude::*;
-import wgsl_test::prelude::*;
+import wgsl_test::expect::*;
 ```
 
 These can then be used anywhere in the source code.
@@ -287,7 +287,7 @@ Advanced users who wish to wildcard import from external modules not marked as
 ```wesl
 // wildcard import from a @wildcardable external
 import bevy::prelude::*;
-import wgsl_test::prelude::*;
+import wgsl_test::expect::*;
 
 // wildcard import from within the local package
 import package::utils::*;

--- a/Imports.md
+++ b/Imports.md
@@ -371,8 +371,8 @@ collisions cannot be suppressed; other diagnostics are suppressible via
 | Local declaration conflicts with named import | Error |
 | Named import conflicts with named import | Error |
 | Wildcard import conflicts with wildcard import (when name is referenced) | Error |
-| Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`); suppressible |
-| Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`); suppressible |
+| Wildcard import from a non-`@wildcardable` external module | Error (`wildcard_import`) on the import; suppressible |
+| Local declaration or named import shadows a wildcard-imported name | Warning (`wildcard_shadow`) on the shadowing declaration; suppressible |
 
 When multiple wildcard imports are in scope, the same name may be exported by
 more than one module. The potential conflict is dormant unless the name is

--- a/ImportsDesign.md
+++ b/ImportsDesign.md
@@ -1,0 +1,95 @@
+# Imports Design
+
+This document records design decisions behind WESL's import system. The
+normative spec lives in [Imports.md](Imports.md).
+
+## Why the `@wildcardable module;` form?
+
+`@wildcardable` is module-level metadata. WESL will likely want module-level
+annotations for other module-scoped features, and libraries and users will want
+a place to attach their own metadata to a whole module. A general-purpose syntax
+for module metadata avoids inventing one ad-hoc form per feature.
+
+The syntax pairs an attribute list with a `module` declaration:
+
+- **`@`-prefixed attributes** match the existing item-level convention
+  (`@group`, `@binding`, `@if`, `@diagnostic`, ...). Module-level metadata uses
+  the same `@name` form, so users learn one annotation convention rather than
+  two, and the `@` always attaches to the element it precedes.
+- **The `module` keyword** anchors the attributes to a declaration, but the
+  keyword is still usable for potential module-level features. For example,
+  syntax like `module(...)`, `module foo::bar`, or `module { ... }` is still
+  available for future use.
+
+See [`@wildcardable` annotation](Imports.md#wildcardable-annotation) for the
+normative spec.
+
+## Aren't wildcards an anti-pattern?
+
+Many language communities discourage wildcard imports. TypeScript, Go, Zig, and
+Carbon disallow wildcards entirely or restrict them to narrow cases. Java and
+Rust permit them syntactically but discourage broad use by convention; Rust's
+`prelude` modules are one curated pattern in that style. The general concerns
+are practical:
+
+- **Readability.** Direct imports make it obvious where a name comes from.
+  Wildcards push that work onto the reader, the language server, or the
+  compiler's name-resolution diagnostics.
+- **API stability.** Adding a public item to a wildcard-imported module can
+  conflict with downstream declarations or with other wildcard imports. Stacked
+  wildcards across a dependency tree can create conflicts the end user neither
+  caused nor can easily fix.
+
+The WESL environment adds further concerns:
+
+- **Cross-ecosystem publishing.** WESL libraries can be published into multiple
+  host ecosystems (npm, crates, etc.), and the language's stability rules have
+  to work for all of them. npm in particular treats minor/patch breakage as an
+  upstream bug, so wildcard-driven conflicts on additive package updates would
+  be read there as buggy packages, not as users accepting a WESL-specific
+  tradeoff. The defaults can't be split per-ecosystem; even libraries that
+  aren't actively cross-published inherit the same rules.
+- **Mixed-language ownership.** In host applications, dependency updates are
+  often routine maintenance handled by someone other than the shader author. A
+  wildcard conflict can land on a teammate who did not cause it and may not be
+  best positioned to fix shader-side breakage.
+- **Shader test coverage.** Shader test coverage is often thinner than
+  application-code coverage, and some failures are visual or runtime-dependent.
+  Fewer tests and WGSL's comparatively small type system mean that wildcard
+  conflicts are less likely to be caught at the moment a dependency is updated.
+- **Single namespace.** WGSL has a single namespace for types and values, and no
+  namespace construct or object-style surface to limit the scope of wildcarded
+  names after import. There are fewer places for names to coexist harmlessly.
+
+These concerns motivate guardrails for WESL wildcard defaults.
+
+## Wildcards in WESL: when to allow, when to gate
+
+WESL keeps wildcards available because some libraries are designed to feel
+pervasive. Game engines, test frameworks, and math libraries expect a
+domain-specific API where prefixing every call with `test::expect::` or similar
+would obscure the shader rather than help it. Concise import syntax matters even
+where an IDE can autocomplete: not every editor has a language server, and long
+import blocks add noise regardless of how they were typed.
+
+But the concerns in
+[Aren't wildcards an anti-pattern?](#arent-wildcards-an-anti-pattern) still
+apply, especially across package boundaries. WESL's defaults try to keep the
+benefits while limiting the risk:
+
+- **Not every public module suits wildcards.** Modules with a fast-growing API
+  or with generic names (`Buffer`, `Result`) are fine to import by name but
+  hazardous to wildcard.
+- **Authors can signal which modules are curated for wildcards.** An explicit
+  `@wildcardable` marker lets library authors tell consumers (and tools) which
+  modules they've designed for wildcard use. It also gives tooling a hook for
+  lints around generic names, builtin shadowing, churn-prone additions, etc.
+- **Defaults shape the ecosystem.** Red/yellow squiggles and linter messages
+  teach safe wildcard practice to new and part-time shader authors more reliably
+  than community blogs or documentation.
+- **Advanced users are not blocked.** Within a package, wildcard imports are
+  unrestricted; externally, wildcard-importing a non-`@wildcardable` module is
+  possible via
+  [standard diagnostic controls](Imports.md#suppressible-diagnostics). The
+  default tunes the path of least resistance, but doesn't block users who
+  intentionally accept the risk.

--- a/ImportsDesign.md
+++ b/ImportsDesign.md
@@ -32,7 +32,7 @@ Rust permit them syntactically but discourage broad use by convention; Rust's
 `prelude` modules are one curated pattern in that style. The general concerns
 are practical:
 
-- **Readability.** Direct imports make it obvious where a name comes from.
+- **Traceability.** Direct imports make it obvious where a name comes from.
   Wildcards push that work onto the reader, the language server, or the
   compiler's name-resolution diagnostics.
 - **API stability.** Adding a public item to a wildcard-imported module can

--- a/ImportsDesign.md
+++ b/ImportsDesign.md
@@ -3,25 +3,22 @@
 This document records design decisions behind WESL's import system. The
 normative spec lives in [Imports.md](Imports.md).
 
-## Why the `@wildcardable module;` form?
+## Why the `@!` module attribute form?
 
-`@wildcardable` is module-level metadata. WESL will likely want module-level
+`@!wildcardable` is module-level metadata. WESL will likely want module-level
 annotations for other module-scoped features, and libraries and users will want
 a place to attach their own metadata to a whole module. A general-purpose syntax
 for module metadata avoids inventing one ad-hoc form per feature.
 
-The syntax pairs an attribute list with a `module` declaration:
+`@!wildcardable` mirrors the item-level attribute convention (`@group`,
+`@binding`, `@if`, `@diagnostic`, ...), but the `!` marks the attribute as
+scoped to the whole module. Unlike an item attribute, it doesn't attach to a
+following element, so a trailing `;` terminates it.
 
-- **`@`-prefixed attributes** match the existing item-level convention
-  (`@group`, `@binding`, `@if`, `@diagnostic`, ...). Module-level metadata uses
-  the same `@name` form, so users learn one annotation convention rather than
-  two, and the `@` always attaches to the element it precedes.
-- **The `module` keyword** anchors the attributes to a declaration, but the
-  keyword is still usable for potential module-level features. For example,
-  syntax like `module(...)`, `module foo::bar`, or `module { ... }` is still
-  available for future use.
+Module attributes sit below the imports so that they can use imported
+names (for example a hypothetical `@!play_version(2);`).
 
-See [`@wildcardable` annotation](Imports.md#wildcardable-annotation) for the
+See [`@!wildcardable` annotation](Imports.md#wildcardable-annotation) for the
 normative spec.
 
 ## Aren't wildcards an anti-pattern?
@@ -81,14 +78,14 @@ benefits while limiting the risk:
   or with generic names (`Buffer`, `Result`) are fine to import by name but
   hazardous to wildcard.
 - **Authors can signal which modules are curated for wildcards.** An explicit
-  `@wildcardable` marker lets library authors tell consumers (and tools) which
+  `@!wildcardable` marker lets library authors tell consumers (and tools) which
   modules they've designed for wildcard use. It also gives tooling a hook for
   lints around generic names, builtin shadowing, churn-prone additions, etc.
 - **Defaults shape the ecosystem.** Red/yellow squiggles and linter messages
   teach safe wildcard practice to new and part-time shader authors more reliably
   than community blogs or documentation.
 - **Advanced users are not blocked.** Within a package, wildcard imports are
-  unrestricted; externally, wildcard-importing a non-`@wildcardable` module is
+  unrestricted; externally, wildcard-importing a non-`@!wildcardable` module is
   possible via
   [standard diagnostic controls](Imports.md#suppressible-diagnostics). The
   default tunes the path of least resistance, but doesn't block users who


### PR DESCRIPTION
fix for #193

replace the left-to-right segment walk with direct resolution:
the last path segment names the declared item, the preceding segments name the module.
    
declarations and modules naturally live in separate namespaces now
- `fn foo() {}` and `foo::bar();` do not conflict
    
lazy vs eager resolution is an implementation choice
    
clarify terms a bit